### PR TITLE
feat: resilience4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,17 +135,17 @@
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>
 			<artifactId>resilience4j-spring-boot2</artifactId>
-			<version>2.2.0</version>
+			<version>1.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>
 			<artifactId>resilience4j-retry</artifactId>
-			<version>2.0.2</version>
+			<version>1.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>
 			<artifactId>resilience4j-bulkhead</artifactId>
-			<version>2.2.0</version>
+			<version>1.7.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
 			<artifactId>resilience4j-retry</artifactId>
 			<version>2.0.2</version>
 		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-bulkhead</artifactId>
+			<version>2.2.0</version>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,16 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-spring-boot2</artifactId>
+			<version>2.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-retry</artifactId>
+			<version>2.0.2</version>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,11 @@ resilience4j:
         sliding-window-size: 10
         wait-duration-in-open-state: 5s
         sliding-window-type: COUNT_BASED
+  bulkhead:
+    instances:
+      paymentService:
+        max-concurrent-calls: 10
+        max-wait-duration: 0ms
 
 management:
   health:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,16 @@ spring:
     - dev
 
 resilience4j:
+  retry:
+    instances:
+      paymentService:
+        max-attempts: 3
+        wait-duration: 500ms
+        retry-exceptions:
+          - org.springframework.web.client.ResourceAccessException
+          - org.springframework.web.client.RestClientException
+        ignore-exceptions:
+          - org.springframework.web.client.HttpClientErrorException$NotFound
   circuitbreaker:
     instances:
       paymentService:


### PR DESCRIPTION
This pull request introduces resilience patterns to the `PaymentServiceImpl` by integrating Resilience4j's retry and bulkhead mechanisms. The changes add dependencies, configuration, and annotations to enable automatic retries and limit concurrent requests for the `save` method, along with appropriate fallback methods to handle failures gracefully.

**Resilience4j Integration:**

* Added Resilience4j dependencies (`resilience4j-spring-boot2`, `resilience4j-retry`, `resilience4j-bulkhead`) to `pom.xml` to support resilience patterns in the project.
* Configured retry and bulkhead settings for the `paymentService` instance in `application.yml`, specifying retry attempts, exceptions to retry or ignore, and concurrent call limits. [[1]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR18-R27) [[2]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR40-R44)

**Service Layer Enhancements:**

* Annotated the `save` method in `PaymentServiceImpl` with `@Bulkhead` and `@Retry` to automatically handle retries and concurrent request limits, and implemented corresponding fallback methods (`saveBulkheadFallback`, `saveFallback`) for graceful degradation. [[1]](diffhunk://#diff-666688fcf53fe23bd2a7d63d085ca193d01ef5d0778b6b7a798c1ffe56aa066aR110-R111) [[2]](diffhunk://#diff-666688fcf53fe23bd2a7d63d085ca193d01ef5d0778b6b7a798c1ffe56aa066aR142-R181)
* Updated exception handling in the `save` method to propagate relevant exceptions, allowing Resilience4j to trigger retries or bulkhead logic as configured. [[1]](diffhunk://#diff-666688fcf53fe23bd2a7d63d085ca193d01ef5d0778b6b7a798c1ffe56aa066aR122-R123) [[2]](diffhunk://#diff-666688fcf53fe23bd2a7d63d085ca193d01ef5d0778b6b7a798c1ffe56aa066aR142-R181)