### PR TITLE
feat: add prometheus dependency and downgrade resilience4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,17 +135,17 @@
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>
 			<artifactId>resilience4j-spring-boot2</artifactId>
-			<version>2.2.0</version>
+			<version>1.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>
 			<artifactId>resilience4j-retry</artifactId>
-			<version>2.0.2</version>
+			<version>1.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>
 			<artifactId>resilience4j-bulkhead</artifactId>
-			<version>2.2.0</version>
+			<version>1.7.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
 			<artifactId>resilience4j-retry</artifactId>
 			<version>2.0.2</version>
 		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-bulkhead</artifactId>
+			<version>2.2.0</version>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,16 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-spring-boot2</artifactId>
+			<version>2.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-retry</artifactId>
+			<version>2.0.2</version>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,11 @@ resilience4j:
         sliding-window-size: 10
         wait-duration-in-open-state: 5s
         sliding-window-type: COUNT_BASED
+  bulkhead:
+    instances:
+      paymentService:
+        max-concurrent-calls: 10
+        max-wait-duration: 0ms
 
 management:
   health:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,16 @@ spring:
     - dev
 
 resilience4j:
+  retry:
+    instances:
+      paymentService:
+        max-attempts: 3
+        wait-duration: 500ms
+        retry-exceptions:
+          - org.springframework.web.client.ResourceAccessException
+          - org.springframework.web.client.RestClientException
+        ignore-exceptions:
+          - org.springframework.web.client.HttpClientErrorException$NotFound
   circuitbreaker:
     instances:
       paymentService:


### PR DESCRIPTION
This pull request adds resilience features to the payment service by integrating Resilience4j for retry and bulkhead patterns. The changes include new dependencies, configuration updates, and code modifications to apply these patterns and handle their fallbacks gracefully.

**Resilience4j Integration and Configuration:**

* Added Resilience4j dependencies (`resilience4j-spring-boot2`, `resilience4j-retry`, `resilience4j-bulkhead`) to `pom.xml` for enabling resilience patterns in the application.
* Configured retry and bulkhead settings for the `paymentService` in `application.yml`, specifying retry attempts, wait durations, exceptions to retry or ignore, and concurrency limits. [[1]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR18-R27) [[2]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR40-R44)

**Service Implementation Enhancements:**

* Annotated the `save` method in `PaymentServiceImpl` with `@Retry` and `@Bulkhead`, and implemented corresponding fallback methods (`saveFallback`, `saveBulkheadFallback`) to handle failures when retries are exhausted or the service is overloaded. [[1]](diffhunk://#diff-666688fcf53fe23bd2a7d63d085ca193d01ef5d0778b6b7a798c1ffe56aa066aR110-R111) [[2]](diffhunk://#diff-666688fcf53fe23bd2a7d63d085ca193d01ef5d0778b6b7a798c1ffe56aa066aR142-R181)
* Updated exception handling in the `save` method to allow certain exceptions to propagate, enabling Resilience4j to properly trigger retries or bulkhead fallback logic. [[1]](diffhunk://#diff-666688fcf53fe23bd2a7d63d085ca193d01ef5d0778b6b7a798c1ffe56aa066aR122-R123) [[2]](diffhunk://#diff-666688fcf53fe23bd2a7d63d085ca193d01ef5d0778b6b7a798c1ffe56aa066aR142-R181)